### PR TITLE
Update Electron to 19

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Installation
 `node16` and `npm` are required for the install<br />
 ```
-sudo pkg install electron13 node16 npm
+sudo pkg install electron19 node16 npm
 git clone https://github.com/z-ffqq/Discord-BSD.git
 cd Discord-BSD
 ./install.sh

--- a/discord
+++ b/discord
@@ -1,5 +1,5 @@
 #!/bin/sh
 cd ~/.local/share/discord-bsd
-echo "Discord 0.0.18"
+echo "Discord 0.1.0"
 sleep 2
 npm run client

--- a/install.sh
+++ b/install.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
-printf "Discord 0.0.18\n"
+printf "Discord 0.1.0\n"
 sleep 1
 printf "Discord native client for FreeBSD\n"
 sleep 0.2
 install() {
 	sleep 0.2
-	printf "Installing Discord 0.0.18 ...\n"
+	printf "Installing Discord 0.1.0 ...\n"
 	mkdir -p ~/.local/share/discord-bsd
 	mkdir -p ~/.local/bin
 	mkdir -p ~/.local/share/applications
@@ -17,6 +17,6 @@ install() {
 	sed -i '' "s/Icon=auto2/Icon=\/home\/$USER\/.local\/share\/discord-bsd\/discord.png/" ~/.local/share/applications/discord.desktop
 	cd /home/$USER/.local/share/discord-bsd
 	npm install
-	printf "Discord 0.0.18 installed!\n"
+	printf "Discord 0.1.0 installed!\n"
 }
 printf "Launching installer...\n" && install

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Discord",
-  "version": "0.0.17",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "Discord",
-      "version": "0.0.17",
+      "version": "0.1.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "electron-builder": "^22.14.5",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Discord Client",
   "main": "index.js",
   "scripts": {
-    "client": "electron13 ."
+    "client": "electron19 ."
   },
   "author": "z-ffqq",
   "license": "BSD-3-Clause",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Discord",
-  "version": "0.0.17",
+  "version": "0.1.0",
   "description": "Discord Client",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
FreeBSD no longer offers Electron 13 via `pkg` (at least not on 14.0-CURRENT), and Electron 13 is getting pretty old now - so I updated it to 19.

With this, I bumped the versions up to `0.1.0`.

Everything seems to work just as it should.